### PR TITLE
fix: Add vercel.json for SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
This configuration ensures that all paths not matching a static file are rewritten to /index.html, allowing client-side routing to handle them correctly on Vercel deployments.